### PR TITLE
3.11: Changed BT disconnect to distinctive vibration pattern

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -4,7 +4,7 @@
   "longName": "Blockslide",
   "companyName": "Jnm",
   "versionCode": 1,
-  "versionLabel": "3.10",
+  "versionLabel": "3.11",
   "watchapp": {
     "watchface": true
   },

--- a/src/Blockslide.c
+++ b/src/Blockslide.c
@@ -478,6 +478,11 @@ void handle_bluetooth(bool connected) {
 
         vibes_double_pulse();
       } else {
+        static const uint32_t const segments[] = {80, 30, 80, 30, 80};
+        VibePattern pat = {
+          .durations = segments,
+          .num_segments = ARRAY_LENGTH(segments),
+        };
         slot[2].curDigit = SPACE_L;
         slot[3].curDigit = SPACE_R;
 
@@ -490,7 +495,7 @@ void handle_bluetooth(bool connected) {
         slot[10].curDigit = 'D' - '0';
         slot[11].curDigit = SPACE_D;
 
-        vibes_long_pulse();
+        vibes_enqueue_custom_pattern(pat);
       }
 
       createAnim();


### PR DESCRIPTION
I love the BT connection alert feature, but since I often walk around the house just out of range of where I left my phone, I find that the long vibrate on disconnect is so close to the notification alert that I check my watch even when nothing interesting is happening.

This changes the disconnection alert to a short triple pulse, so that you can identify a BT disconnect without looking; the reconnect pattern is still the standard double pulse.
